### PR TITLE
Autofocus cancel button

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Usage
       title: "Confirmation",
       cancelText: "Cancel",
       okText: "Ok",
-      success: true // wether the button should be green or red
+      success: true, // whether the button should be green or red
+      focus: "cancel" // which button to autofocus, "cancel" (default) or "ok", or "none"
     }, function (ok) {
       // ok is true if the user clicked on "ok", false otherwise
     });

--- a/lib/popup-confirm.css
+++ b/lib/popup-confirm.css
@@ -49,12 +49,14 @@
   margin-left: 10%;
 }
 
-.pc-container .pc-button:hover {
+.pc-container .pc-button:hover, .pc-container .pc-button:focus {
   background: currentColor;
+  outline: none;
 }
 
-.pc-container .pc-button:hover > span {
+.pc-container .pc-button:hover > span, .pc-container .pc-button:focus > span {
   color: #FFF;
+  outline: none;
 }
 
 .pc-container .pc-button.pc-button-cancel {

--- a/lib/popup-confirm.js
+++ b/lib/popup-confirm.js
@@ -6,16 +6,17 @@ Confirmation = (function () {
 
     this._id = new Mongo.ObjectID().toHexString();
 
-    _options = _options || {};
-
-    this.view = Blaze.renderWithData(Template.popup_confirm, {
+    this.options = {
       message: _options.message || "",
       title: _options.title || "",
       cancelText: _options.cancelText || "Cancel",
       okText: _options.okText || "Ok",
       success: _options.success,
+      focus: _options.focus || "cancel",
       _id: this._id
-    }, document.body);
+    };
+
+    this.view = Blaze.renderWithData(Template.popup_confirm, this.options, document.body);
 
     Meteor.setTimeout(function() {self._init();}, 50);
 
@@ -33,7 +34,8 @@ Confirmation = (function () {
     this.okButton      = this.popup.find("#pc-ok");
     this.cancelButton  = this.popup.find("#pc-cancel");
 
-    this.cancelButton.focus();
+    if (this.options.focus.toLowerCase() === 'ok') this.okButton.focus();
+    else if (this.options.focus.toLowerCase() === 'cancel') this.cancelButton.focus();
 
     // TODO create a form and listen to submit
     this._okListener = this._okListener.bind(this);

--- a/lib/popup-confirm.js
+++ b/lib/popup-confirm.js
@@ -33,6 +33,8 @@ Confirmation = (function () {
     this.okButton      = this.popup.find("#pc-ok");
     this.cancelButton  = this.popup.find("#pc-cancel");
 
+    this.cancelButton.focus();
+
     // TODO create a form and listen to submit
     this._okListener = this._okListener.bind(this);
     this._cancelListener = this._cancelListener.bind(this);


### PR DESCRIPTION
Makes it easier using the popup with keyboard only. The cancel button is autofocused, so that pressing enter will close the popup. OK button is just one tap of the TAB key away. The reason the OK button is not autofocused is because accidentally pressing enter could then potentially cause harm.
