### PR TITLE
Update media query for mobile display offset

### DIFF
--- a/lib/popup-confirm.css
+++ b/lib/popup-confirm.css
@@ -30,6 +30,7 @@
 @media (max-width:768px) {
   .pc-container {
     width : 350px;
+    left: calc(50% - 175px);
   }
 }
 


### PR DESCRIPTION
The media query resized the popup to fit smaller screens, but did not update the left offset. This resulted in the popup being off center and text being unreadable.

The commit adds a new left offset to the media query and fixes the issue.